### PR TITLE
Update criterion version. Fix cargo bench

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/algesten/froop"
 [dependencies]
 
 [dev-dependencies]
-criterion = "0.2"
+criterion = "0.3"
 
 [[bench]]
 name = "stream_benchmark"


### PR DESCRIPTION
On `criterion = "0.2"` I got this backtrace on `cargo bench`:
<details>
 <summary>Full backtrace</summary>

```rust
$ RUST_BACKTRACE=full cargo bench
    Finished bench [optimized] target(s) in 0.14s
     Running unittests (target/release/deps/froop-ec1d5c50f4cf2cf7)

running 12 tests
test peg::test::test_peg_keep_mode ... ignored
test peg::test::test_peg_no_keep ... ignored
test test::test_chained_maps ... ignored
test test::test_combine ... ignored
test test::test_fold_and_last ... ignored
test test::test_fold_and_remember ... ignored
test test::test_imitate ... ignored
test test::test_imitate_cycle ... ignored
test test::test_of ... ignored
test test::test_sink_auto_traits ... ignored
test test::test_stream_auto_traits ... ignored
test test::test_subscription_auto_traits ... ignored

test result: ok. 0 passed; 0 failed; 12 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests (target/release/deps/stream_benchmark-97a27ea2f266098f)
Gnuplot not found, disabling plotting
Benchmarking map: Analyzingthread '<unnamed>' panicked at 'attempted to leave type `nodrop::NoDrop<(epoch::Epoch, garbage::Bag)>` uninitialized, which is invalid', /rustc/a178d0322ce20e33eac124758e837cbd80a6f633/library/core/src/mem/mod.rs:660:9
stack backtrace:
   0:        0x1014209b4 - std::backtrace_rs::backtrace::libunwind::trace::h03e89bdd1996f493
                               at /rustc/a178d0322ce20e33eac124758e837cbd80a6f633/library/std/src/../../backtrace/src/backtrace/libunwind.rs:90:5
   1:        0x1014209b4 - std::backtrace_rs::backtrace::trace_unsynchronized::hb5af08e4de8ca785
                               at /rustc/a178d0322ce20e33eac124758e837cbd80a6f633/library/std/src/../../backtrace/src/backtrace/mod.rs:66:5
   2:        0x1014209b4 - std::sys_common::backtrace::_print_fmt::h4eafc628aec41041
                               at /rustc/a178d0322ce20e33eac124758e837cbd80a6f633/library/std/src/sys_common/backtrace.rs:67:5
   3:        0x1014209b4 - <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt::h6a8908fa3ed6f9e8
                               at /rustc/a178d0322ce20e33eac124758e837cbd80a6f633/library/std/src/sys_common/backtrace.rs:46:22
   4:        0x10144130c - core::fmt::write::h4be00f71c5582919
                               at /rustc/a178d0322ce20e33eac124758e837cbd80a6f633/library/core/src/fmt/mod.rs:1110:17
   5:        0x10141d1fa - std::io::Write::write_fmt::h49e76926070788f1
                               at /rustc/a178d0322ce20e33eac124758e837cbd80a6f633/library/std/src/io/mod.rs:1588:15
   6:        0x1014227af - std::sys_common::backtrace::_print::h2f7b8ad2bea4f859
                               at /rustc/a178d0322ce20e33eac124758e837cbd80a6f633/library/std/src/sys_common/backtrace.rs:49:5
   7:        0x1014227af - std::sys_common::backtrace::print::h97402070cfceb1a3
                               at /rustc/a178d0322ce20e33eac124758e837cbd80a6f633/library/std/src/sys_common/backtrace.rs:36:9
   8:        0x1014227af - std::panicking::default_hook::{{closure}}::h1577f0656e419c0e
                               at /rustc/a178d0322ce20e33eac124758e837cbd80a6f633/library/std/src/panicking.rs:208:50
   9:        0x1014222ad - std::panicking::default_hook::h1aef594179c4fd25
                               at /rustc/a178d0322ce20e33eac124758e837cbd80a6f633/library/std/src/panicking.rs:225:9
  10:        0x101422eb0 - std::panicking::rust_panic_with_hook::h10bc487d002f6c42
                               at /rustc/a178d0322ce20e33eac124758e837cbd80a6f633/library/std/src/panicking.rs:622:17
  11:        0x101422929 - std::panicking::begin_panic_handler::{{closure}}::hf4cfa78c105ce648
                               at /rustc/a178d0322ce20e33eac124758e837cbd80a6f633/library/std/src/panicking.rs:517:13
  12:        0x101420e28 - std::sys_common::backtrace::__rust_end_short_backtrace::h1df96a166e4351c4
                               at /rustc/a178d0322ce20e33eac124758e837cbd80a6f633/library/std/src/sys_common/backtrace.rs:141:18
  13:        0x1014228ba - rust_begin_unwind
                               at /rustc/a178d0322ce20e33eac124758e837cbd80a6f633/library/std/src/panicking.rs:515:5
  14:        0x10145494f - core::panicking::panic_fmt::hea8fe6c9e0720810
                               at /rustc/a178d0322ce20e33eac124758e837cbd80a6f633/library/core/src/panicking.rs:92:14
  15:        0x1014548a7 - core::panicking::panic::hbb13bbcfbaa2890b
                               at /rustc/a178d0322ce20e33eac124758e837cbd80a6f633/library/core/src/panicking.rs:50:5
  16:        0x1013af6a7 - std::sync::once::Once::call_once::{{closure}}::h791d0a32a18872bc
  17:        0x10145408c - std::sync::once::Once::call_inner::hc0ba77f0e2244142
                               at /rustc/a178d0322ce20e33eac124758e837cbd80a6f633/library/std/src/sync/once.rs:418:21
  18:        0x1013b0019 - <crossbeam_epoch::default::COLLECTOR as core::ops::deref::Deref>::deref::hc28d2fae8c40923e
  19:        0x1013aeff9 - std::thread::local::fast::Key<T>::try_initialize::h8ed8d633fb34da20
  20:        0x1013ad8cc - crossbeam_deque::Stealer<T>::steal::h367e50383e46932c
  21:        0x1013ac4bb - <core::iter::adapters::chain::Chain<A,B> as core::iter::traits::iterator::Iterator>::try_fold::h3651644dca2e6bc9
  22:        0x10144f6ed - rayon_core::registry::WorkerThread::wait_until_cold::h0bd912d48147e550
  23:        0x1013ac10f - rayon_core::registry::main_loop::h0bda40e9eef0d3ed
  24:        0x1013ad6a4 - std::sys_common::backtrace::__rust_begin_short_backtrace::h1f5384995356e919
  25:        0x1013ad2c9 - core::ops::function::FnOnce::call_once{{vtable.shim}}::hf9ef01a30c5fdfb0
  26:        0x1014284fb - <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once::hd1aaf96bb4a825cd
                               at /rustc/a178d0322ce20e33eac124758e837cbd80a6f633/library/alloc/src/boxed.rs:1575:9
  27:        0x1014284fb - <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once::h85328f151de296fc
                               at /rustc/a178d0322ce20e33eac124758e837cbd80a6f633/library/alloc/src/boxed.rs:1575:9
  28:        0x1014284fb - std::sys::unix::thread::Thread::new::thread_start::h63f8b299c7b9d50c
                               at /rustc/a178d0322ce20e33eac124758e837cbd80a6f633/library/std/src/sys/unix/thread.rs:71:17
  29:     0x7fff73671109 - __pthread_start
error: process didn't exit successfully: `<anon>/froop/target/release/deps/stream_benchmark-97a27ea2f266098f --bench` (signal: 11, SIGSEGV: invalid memory reference)

[101] $
```

</details>

Fixed by updating to `criterion = "0.3"`