### PR TITLE
Add example folder & fix clippy warnings

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,0 +1,22 @@
+use froop::{Sink, Stream};
+
+fn main() {
+    // A sink is an originator of events that form a stream.
+    let sink: Sink<u32> = Stream::sink();
+
+    // Map the even numbers to their square.
+    let stream: Stream<u32> = sink.stream().filter(|i| i % 2 == 0).map(|i| i * i);
+
+    // Print the result
+    stream.subscribe(|i| {
+        if let Some(i) = i {
+            println!("{}", i)
+        }
+    });
+
+    // Send numbers into the sink.
+    for i in 0..10 {
+        sink.update(i);
+    }
+    sink.end();
+}

--- a/src/inner.rs
+++ b/src/inner.rs
@@ -12,7 +12,7 @@ impl<T> SafeInner<T> {
     pub(crate) fn new(memory_mode: MemoryMode, memory: Option<T>) -> Self {
         SafeInner(Arc::new(Mutex::new(Inner::new(memory_mode, memory))))
     }
-    pub(crate) fn lock<'a>(&'a self) -> MutexGuard<'a, Inner<T>> {
+    pub(crate) fn lock(&self) -> MutexGuard<Inner<T>> {
         self.0.lock().unwrap()
     }
 }
@@ -26,10 +26,7 @@ pub(crate) enum MemoryMode {
 
 impl MemoryMode {
     pub fn is_memory(self) -> bool {
-        match self {
-            MemoryMode::NoMemory => false,
-            _ => true,
-        }
+        !matches!(self, MemoryMode::NoMemory)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -592,7 +592,7 @@ impl<T> Stream<T> {
                         // this is one clone too many. if we could use
                         // Box<FnOnce> on stable, we would do that instead
                         let t = t_clone.clone();
-                        imitator_clone.lock().update_owned(t.clone());
+                        imitator_clone.lock().update_owned(t);
                     }));
                 });
             } else {


### PR DESCRIPTION
<details>
 <summary>Clippy warnings</summary>

```rust
$ cargo clippy
    Checking froop v0.1.1 (<anon>/froop)
warning: explicit lifetimes given in parameter types where they could be elided (or replaced with `'_` if needed by type declaration)
  --> src/inner.rs:15:5
   |
15 |     pub(crate) fn lock<'a>(&'a self) -> MutexGuard<'a, Inner<T>> {
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
note: the lint level is defined here
  --> src/lib.rs:89:9
   |
89 | #![warn(clippy::all)]
   |         ^^^^^^^^^^^
   = note: `#[warn(clippy::needless_lifetimes)]` implied by `#[warn(clippy::all)]`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes

warning: match expression looks like `matches!` macro
  --> src/inner.rs:29:9
   |
29 | /         match self {
30 | |             MemoryMode::NoMemory => false,
31 | |             _ => true,
32 | |         }
   | |_________^ help: try this: `!matches!(self, MemoryMode::NoMemory)`
   |
note: the lint level is defined here
  --> src/lib.rs:89:9
   |
89 | #![warn(clippy::all)]
   |         ^^^^^^^^^^^
   = note: `#[warn(clippy::match_like_matches_macro)]` implied by `#[warn(clippy::all)]`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#match_like_matches_macro

warning: redundant clone
   --> src/lib.rs:595:61
    |
595 |                         imitator_clone.lock().update_owned(t.clone());
    |                                                             ^^^^^^^^ help: remove this
    |
note: the lint level is defined here
   --> src/lib.rs:89:9
    |
89  | #![warn(clippy::all)]
    |         ^^^^^^^^^^^
    = note: `#[warn(clippy::redundant_clone)]` implied by `#[warn(clippy::all)]`
note: this value is dropped without further use
   --> src/lib.rs:595:60
    |
595 |                         imitator_clone.lock().update_owned(t.clone());
    |                                                            ^
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_clone

warning: 3 warnings emitted

    Finished dev [unoptimized + debuginfo] target(s) in 1.13s
```

</details>